### PR TITLE
feat: Implement UI component for select

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,6 +26,7 @@ import { initEditor } from "./editor";
 import { toMarkdown } from "./to_markdown";
 import { debounce } from "./utils";
 import { FileUpload } from "./fileUpload";
+import componentHooks from "./componentHooks";
 
 let csrfToken = document
   .querySelector("meta[name='csrf-token']")
@@ -33,6 +34,7 @@ let csrfToken = document
 
 // phoenix hooks
 const Hooks = {
+  ...componentHooks,
   MdEditor: {
     mounted() {
       const autoSave = debounce((editor, textarea) => {

--- a/assets/js/componentHooks.js
+++ b/assets/js/componentHooks.js
@@ -1,0 +1,79 @@
+const select = {
+  mounted() {
+    const el = this.el;
+
+    // close select popup
+    function dismissSelect(event) {
+      const target = event?.target || el.querySelector(".select-content");
+      target.classList.add("hidden");
+      target.removeEventListener("dismiss", dismissSelect);
+    }
+
+    // update display label of selected option
+    function updateDisplayLabel() {
+      el.querySelector(".select-value").innerText = el.querySelector(
+        `input:checked ~ .select-item-label`
+      )?.innerText;
+    }
+
+    // propgate name to all inputs
+    const name = el.getAttribute("data-name");
+    if (name)
+      el.querySelectorAll(`input`).forEach((input) => {
+        input.setAttribute("name", name);
+      });
+
+    // checked selected value
+    const value = el.getAttribute("data-value");
+    if (value) {
+      el.querySelector(`input[value="${value}"]`).checked = true;
+      updateDisplayLabel();
+    }
+
+    // add event listener trigger select
+    el.querySelector(".select-trigger").addEventListener("click", () => {
+      const contentEl = el.querySelector(".select-content");
+      contentEl.classList.toggle("hidden");
+
+      setTimeout(() => {
+        // handle click outside
+        if (!contentEl.classList.contains("hidden")) {
+          // set focus on selected option or first option
+          const selectedOption = contentEl.querySelector("input:checked");
+          if (selectedOption) {
+            selectedOption.focus();
+          } else {
+            contentEl.querySelector("input")?.focus();
+          }
+          contentEl.addEventListener("dismiss", dismissSelect);
+        } else {
+          dismissSelect();
+        }
+      }, 100);
+    });
+
+    // handle click on option
+    el.querySelectorAll(".select-content input").forEach((option) => {
+      option.addEventListener("change", (event) => {
+        if (event.target.checked) {
+          updateDisplayLabel();
+          dismissSelect();
+        }
+      });
+    });
+
+    // handle escape or enter key
+    el.querySelector(".select-content").addEventListener("keydown", (event) => {
+      if (event.key === "Escape" || event.key === "Enter") {
+        dismissSelect();
+        event.preventDefault();
+        event.stopPropagation();
+        return false;
+      }
+    });
+  },
+};
+
+export default {
+  "shad-select": select,
+};

--- a/lib/orange_cms/projects/project.ex
+++ b/lib/orange_cms/projects/project.ex
@@ -4,13 +4,13 @@ defmodule OrangeCms.Projects.Project do
 
   @primary_key {:id, :string, autogenerate: {OrangeCms.Shared.Nanoid, :generate, []}}
   schema "projects" do
-    field :name, :string
-    field :type, Ecto.Enum, values: [:github, :headless_cms], default: :github
-    field :image, :string
-    field :setup_completed, :boolean, default: false
-    field :github_config, :map, default: %{}
-    belongs_to :owner, OrangeCms.Account.User
-    has_many :project_users, OrangeCms.Projects.ProjectUser
+    field(:name, :string)
+    field(:type, Ecto.Enum, values: [:github, :headless_cms], default: :github)
+    field(:image, :string)
+    field(:setup_completed, :boolean, default: false)
+    field(:github_config, :map, default: %{})
+    belongs_to(:owner, OrangeCms.Account.User)
+    has_many(:project_users, OrangeCms.Projects.ProjectUser)
 
     timestamps()
   end

--- a/lib/orange_cms_web.ex
+++ b/lib/orange_cms_web.ex
@@ -90,6 +90,7 @@ defmodule OrangeCmsWeb do
       import OrangeCmsWeb.Components.Form
       import OrangeCmsWeb.Components.Input, except: [input: 1]
       import OrangeCmsWeb.Components.JS
+      import OrangeCmsWeb.Components.Select
       import OrangeCmsWeb.Components.Table
       import OrangeCmsWeb.Components.Tooltip
       import OrangeCmsWeb.CoreComponents

--- a/lib/orange_cms_web/components/card.ex
+++ b/lib/orange_cms_web/components/card.ex
@@ -22,67 +22,74 @@ defmodule OrangeCmsWeb.Components.Card do
           </.card_footer>
         </.card>
   """
-  attr :class, :string, default: nil
-  slot :inner_block, required: true
+
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+  attr(:rest, :global)
 
   def card(assigns) do
     ~H"""
-    <div class={["rounded-xl border bg-card text-card-foreground shadow", @class]}>
+    <div class={["rounded-xl border bg-card text-card-foreground shadow", @class]} {@rest}>
       <%= render_slot(@inner_block) %>
     </div>
     """
   end
 
-  attr :class, :string, default: nil
-  slot :inner_block, required: true
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+  attr(:rest, :global)
 
   def card_header(assigns) do
     ~H"""
-    <div class={["flex flex-col space-y-1.5 p-6", @class]}>
+    <div class={["flex flex-col space-y-1.5 p-6", @class]} {@rest}>
       <%= render_slot(@inner_block) %>
     </div>
     """
   end
 
-  attr :class, :string, default: nil
-  slot :inner_block, required: true
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+  attr(:rest, :global)
 
   def card_title(assigns) do
     ~H"""
-    <h3 class={["font-semibold leading-none tracking-tight", @class]}>
+    <h3 class={["font-semibold leading-none tracking-tight", @class]} {@rest}>
       <%= render_slot(@inner_block) %>
     </h3>
     """
   end
 
-  attr :class, :string, default: nil
-  slot :inner_block, required: true
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+  attr(:rest, :global)
 
   def card_description(assigns) do
     ~H"""
-    <p class={["text-sm text-muted-foreground", @class]}>
+    <p class={["text-sm text-muted-foreground", @class]} {@rest}>
       <%= render_slot(@inner_block) %>
     </p>
     """
   end
 
-  attr :class, :string, default: nil
-  slot :inner_block, required: true
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+  attr(:rest, :global)
 
   def card_content(assigns) do
     ~H"""
-    <div class={["p-6 pt-0", @class]}>
+    <div class={["p-6 pt-0", @class]} {@rest}>
       <%= render_slot(@inner_block) %>
     </div>
     """
   end
 
-  attr :class, :string, default: nil
-  slot :inner_block, required: true
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+  attr(:rest, :global)
 
   def card_footer(assigns) do
     ~H"""
-    <div class={["flex items-center justify-between p-6 pt-0 ", @class]}>
+    <div class={["flex items-center justify-between p-6 pt-0 ", @class]} {@rest}>
       <%= render_slot(@inner_block) %>
     </div>
     """

--- a/lib/orange_cms_web/components/component_helpers.ex
+++ b/lib/orange_cms_web/components/component_helpers.ex
@@ -1,0 +1,21 @@
+defmodule OrangeCmsWeb.Components.ComponentHelpers do
+  import Phoenix.Component
+
+  @doc """
+  Prepare input assigns for use in a form. Extract required attribute from the Form.Field struct and update current assigns.
+  """
+  def prepare_assign(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
+    assigns
+    |> assign(field: nil, id: assigns.id || field.id)
+    |> assign_new(:name, fn ->
+      if assigns[:multiple] == true,
+        do: field.name <> "[]",
+        else: field.name
+    end)
+    |> assign_new(:value, fn -> field.value end)
+  end
+
+  def prepare_assign(assigns) do
+    assigns
+  end
+end

--- a/lib/orange_cms_web/components/input.ex
+++ b/lib/orange_cms_web/components/input.ex
@@ -3,22 +3,27 @@ defmodule OrangeCmsWeb.Components.Input do
   Implement of form component
   """
   use Phoenix.Component
+  alias OrangeCmsWeb.Components.ComponentHelpers
 
-  attr :id, :any, default: nil
-  attr :name, :any
-  attr :value, :any
+  attr(:id, :any, default: nil)
+  attr(:name, :any)
+  attr(:value, :any)
 
-  attr :type, :string,
+  attr(:type, :string,
     default: "text",
     values: ~w(date datetime-local email file hidden month number password
       tel text time url week)
+  )
 
-  attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form, for example: @form[:email]"
-  attr :class, :string, default: nil
-  attr :rest, :global
+  attr(:field, Phoenix.HTML.FormField,
+    doc: "a form field struct retrieved from the form, for example: @form[:email]"
+  )
+
+  attr(:class, :string, default: nil)
+  attr(:rest, :global)
 
   def input(assigns) do
-    assigns = prepare_assign(assigns)
+    assigns = ComponentHelpers.prepare_assign(assigns)
 
     ~H"""
     <input
@@ -44,16 +49,16 @@ defmodule OrangeCmsWeb.Components.Input do
 
       <.textarea field={@form[:name]} class="h-32">My content</.textarea>
   """
-  attr :id, :any, default: nil
-  attr :name, :any, default: nil
-  attr :value, :any, default: nil
-  attr :field, Phoenix.HTML.FormField
-  attr :class, :string, default: nil
-  attr :rest, :global
-  slot :inner_block
+  attr(:id, :any, default: nil)
+  attr(:name, :any, default: nil)
+  attr(:value, :any, default: nil)
+  attr(:field, Phoenix.HTML.FormField)
+  attr(:class, :string, default: nil)
+  attr(:rest, :global)
+  slot(:inner_block)
 
   def textarea(assigns) do
-    assigns = prepare_assign(assigns)
+    assigns = ComponentHelpers.prepare_assign(assigns)
 
     ~H"""
     <textarea
@@ -76,18 +81,20 @@ defmodule OrangeCmsWeb.Components.Input do
       <.checkbox field={@form[:remember_me]} />
       <.checkbox class="!border-destructive" name="agree" value={true} />
   """
-  attr :id, :any, default: nil
-  attr :name, :any, default: nil
-  attr :value, :any, default: nil
-  attr :field, Phoenix.HTML.FormField
-  attr :class, :string, default: nil
-  attr :rest, :global
+  attr(:id, :any, default: nil)
+  attr(:name, :any, default: nil)
+  attr(:value, :any, default: nil)
+  attr(:field, Phoenix.HTML.FormField)
+  attr(:class, :string, default: nil)
+  attr(:rest, :global)
 
   def checkbox(assigns) do
     assigns =
       assigns
-      |> prepare_assign()
-      |> assign_new(:checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", assigns.value) end)
+      |> ComponentHelpers.prepare_assign()
+      |> assign_new(:checked, fn ->
+        Phoenix.HTML.Form.normalize_value("checkbox", assigns.value)
+      end)
 
     ~H"""
     <input type="hidden" name={@name} value="false" />
@@ -118,18 +125,20 @@ defmodule OrangeCmsWeb.Components.Input do
         <.label for="airplane-mode">Airplane Mode</.label>
       </div>
   """
-  attr :id, :any, default: nil
-  attr :name, :any, default: nil
-  attr :value, :any, default: nil
-  attr :field, Phoenix.HTML.FormField
-  attr :class, :string, default: nil
-  attr :rest, :global
+  attr(:id, :any, default: nil)
+  attr(:name, :any, default: nil)
+  attr(:value, :any, default: nil)
+  attr(:field, Phoenix.HTML.FormField)
+  attr(:class, :string, default: nil)
+  attr(:rest, :global)
 
   def switch(assigns) do
     assigns =
       assigns
-      |> prepare_assign()
-      |> assign_new(:checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", assigns.value) end)
+      |> ComponentHelpers.prepare_assign()
+      |> assign_new(:checked, fn ->
+        Phoenix.HTML.Form.normalize_value("checkbox", assigns.value)
+      end)
 
     ~H"""
     <label class={["relative inline-flex items-center p-0.5 h-[24px] w-[44px]", @class]} {@rest}>
@@ -148,16 +157,5 @@ defmodule OrangeCmsWeb.Components.Input do
       </span>
     </label>
     """
-  end
-
-  defp prepare_assign(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
-    assigns
-    |> assign(field: nil, id: assigns.id || field.id)
-    |> assign_new(:name, fn -> if assigns[:multiple] == true, do: field.name <> "[]", else: field.name end)
-    |> assign_new(:value, fn -> field.value end)
-  end
-
-  defp prepare_assign(assigns) do
-    assigns
   end
 end

--- a/lib/orange_cms_web/components/select.ex
+++ b/lib/orange_cms_web/components/select.ex
@@ -1,0 +1,191 @@
+defmodule OrangeCmsWeb.Components.Select do
+  @moduledoc """
+  Implement of select components from https://ui.shadcn.com/docs/components/select
+  This component require javascript to work properly.
+
+  Read more in assets/js/componentHooks.js
+
+
+  ## Examples:
+
+      <form>
+         <.select default="banana" id="fruit-select">
+            <.select_trigger class="w-[180px]">
+              <.select_value placeholder=".select a fruit"/>
+            </.select_trigger>
+            <.select_content>
+              <.select_group>
+                <.select_label>Fruits</.select_label>
+                <.select_item name="fruit" value="apple">Apple</.select_item>
+                <.select_item name="fruit" value="banana">Banana</.select_item>
+                <.select_item name="fruit" value="blueberry">Blueberry</.select_item>
+                <.select_separator />
+                <.select_item  name="fruit" disabled value="grapes">Grapes</.select_item>
+                <.select_item  name="fruit" value="pineapple">Pineapple</.select_item>
+              </.select_group>
+        </.select_content>
+          </.select>
+
+        <.button type="submit">Submit</.button>
+      </form>
+
+
+  ## Examples with form field:
+
+      <.select id="type-select" class="w-full">
+        <.select_trigger class="w-full">
+            <.select_value placeholder="Select project type" />
+        </.select_trigger>
+        <.select_content>
+            <.select_group>
+                <.select_label>Project type</.select_label>
+                <.select_item :for={type <- ["github", "headless_cms" ]} name="fruit" value={type}><%= type %></.select_item>
+            </.select_group>
+        </.select_content>
+      </.select>
+  """
+  use Phoenix.Component
+  alias Phoenix.LiveView.JS
+  alias OrangeCmsWeb.Components.ComponentHelpers
+
+  attr(:id, :string, required: true)
+  attr(:name, :any)
+  attr(:value, :any)
+
+  attr(:field, Phoenix.HTML.FormField,
+    doc: "a form field struct retrieved from the form, for example: @form[:email]"
+  )
+
+  attr(:default, :any, default: nil)
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+  attr(:rest, :global)
+
+  def select(assigns) do
+    assigns = ComponentHelpers.prepare_assign(assigns)
+    assigns = assign(assigns, :value, assigns[:value] || assigns[:default])
+
+    ~H"""
+    <div
+      id={@id}
+      class={["relative inline-block", @class]} {@rest}
+      data-value={assigns[:value]}
+      data-name={assigns[:name]}
+      phx-hook="shad-select"
+    >
+      <%= render_slot(@inner_block) %>
+    </div>
+    """
+  end
+
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+  attr(:rest, :global)
+
+  def select_trigger(assigns) do
+    ~H"""
+    <button
+      type="button"
+      class={[
+        "select-trigger flex h-10 w-full px-3 py-2 items-center justify-between rounded-md border border-input bg-transparent text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        @class
+      ]}
+      {@rest}
+    >
+      <%= render_slot(@inner_block) %>
+    </button>
+    """
+  end
+
+  attr(:placeholder, :string, default: nil)
+
+  def select_value(assigns) do
+    ~H"""
+    <span class="select-value pointer-events-none before:content-[attr(data-content)]" phx-update="ignore" id={"select-value-#{:rand.uniform(999999)}"}><%= @placeholder %></span>
+    """
+  end
+
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+  attr(:rest, :global)
+
+  def select_content(assigns) do
+    ~H"""
+    <div
+      class={[
+        "select-content hidden transition-all absolute top-full mt-2 left-0 w-full z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        @class
+      ]}
+      {@rest}
+      phx-click-away={JS.dispatch("dismiss")}
+    >
+      <div class="p-1 w-full">
+        <%= render_slot(@inner_block) %>
+      </div>
+    </div>
+    """
+  end
+
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+  attr(:rest, :global)
+
+  def select_group(assigns) do
+    ~H"""
+    <div role="group" class={[@class]} {@rest}>
+      <%= render_slot(@inner_block) %>
+    </div>
+    """
+  end
+
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+  attr(:rest, :global)
+
+  def select_label(assigns) do
+    ~H"""
+    <div class={["py-1.5 pl-8 pr-2 text-sm font-semibold", @class]} {@rest}>
+      <%= render_slot(@inner_block) %>
+    </div>
+    """
+  end
+
+  attr(:name, :string, default: nil)
+  attr(:value, :any, default: nil)
+  attr(:checked, :boolean, default: false)
+  attr(:disabled, :boolean, default: false)
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+
+  attr(:rest, :global)
+
+  def select_item(assigns) do
+    ~H"""
+    <label
+      role="option"
+      class={[
+        "group relative flex w-full overflow-hidden cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground  data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        @class
+      ]}
+      {%{"data-disabled": @disabled}}
+      {@rest}
+    >
+      <input type="radio" name={@name} disabled={@disabled} checked={@checked}
+        class="select-item peer sr-only" value={@value}
+        id={@value}
+      />
+      <div class="absolute top-0 left-0 w-full h-full peer-focus:bg-accent"></div>
+      <span class="absolute left-2 flex h-3.5 w-3.5 items-center justify-center opacity-0 peer-checked:opacity-100">
+        <Heroicons.check class="h-4 w-4" />
+      </span>
+      <span class="select-item-label z-0 peer-focus:text-accent-foreground"><%= render_slot(@inner_block) %></span>
+    </label>
+    """
+  end
+
+  def select_separator(assigns) do
+    ~H"""
+    <div class={["-mx-1 my-1 h-px bg-muted"]}></div>
+    """
+  end
+end

--- a/lib/orange_cms_web/live/project_live/form_component.ex
+++ b/lib/orange_cms_web/live/project_live/form_component.ex
@@ -17,12 +17,8 @@ defmodule OrangeCmsWeb.ProjectLive.FormComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <.form_item>
-          <.form_label>What is your project's name?</.form_label>
-          <.form_control>
+        <.form_item field={@form[:name]} label="What is your project's name?">
             <Input.input field={@form[:name]} type="text" phx-debounce="500" />
-          </.form_control>
-          <.form_message field={@form[:name]} />
         </.form_item>
         <div class="w-full flex flex-row-reverse">
           <.button icon="inbox_arrow_down" phx-disable-with="Saving...">

--- a/lib/orange_cms_web/live/project_live/index.html.heex
+++ b/lib/orange_cms_web/live/project_live/index.html.heex
@@ -39,3 +39,7 @@
     />
   </.dialog_content>
 </.dialog>
+
+<div before="Hello World" class="before:content-[attr(before)]">
+  <!-- ... -->
+</div>


### PR DESCRIPTION
- using js hook to handle client interaction with select

## screenshot

![Screenshot 2023-07-03 at 4 53 00 PM](https://github.com/bluzky/orangecms/assets/6194779/7d1fef39-3636-47dc-9f5a-b5bf884a70f2)


## Examples:

      <form>
         <.select default="banana" id="fruit-select">
            <.select_trigger class="w-[180px]">
              <.select_value placeholder=".select a fruit"/>
            </.select_trigger>
            <.select_content>
              <.select_group>
                <.select_label>Fruits</.select_label>
                <.select_item name="fruit" value="apple">Apple</.select_item>
                <.select_item name="fruit" value="banana">Banana</.select_item>
                <.select_item name="fruit" value="blueberry">Blueberry</.select_item>
                <.select_separator />
                <.select_item  name="fruit" disabled value="grapes">Grapes</.select_item>
                <.select_item  name="fruit" value="pineapple">Pineapple</.select_item>
              </.select_group>
        </.select_content>
          </.select>

        <.button type="submit">Submit</.button>
      </form>

## Use with FormField

      <.select id="type-select" class="w-full">
        <.select_trigger class="w-full">
            <.select_value placeholder="Select project type" />
        </.select_trigger>
        <.select_content>
            <.select_group>
                <.select_label>Project type</.select_label>
                <.select_item :for={type <- ["github", "headless_cms" ]} name="fruit" value={type}><%= type %></.select_item>
            </.select_group>
        </.select_content>
      </.select>